### PR TITLE
klte-common: thermal-engine: cool it off, yo

### DIFF
--- a/configs/thermal-engine-8974.conf
+++ b/configs/thermal-engine-8974.conf
@@ -1,5 +1,69 @@
 sampling         5000
 
+[SS-CPU0]
+#algo_type       ss
+sampling         100
+sensor           cpu0
+device           cpu
+set_point        75000
+set_point_clr    60000
+override         15000
+
+[SS-CPU1]
+#algo_type       ss
+sampling         100
+sensor           cpu1
+device           cpu
+set_point        75000
+set_point_clr    60000
+override         15000
+
+[SS-CPU2]
+#algo_type       ss
+sampling         100
+sensor           cpu2
+device           cpu
+set_point        75000
+set_point_clr    60000
+override         15000
+
+[SS-CPU3]
+#algo_type       ss
+sampling         100
+sensor           cpu3
+device           cpu
+set_point        75000
+set_point_clr    60000
+override         15000
+
+[SS-GPU]
+#algo_type       ss
+sampling         250
+sensor           tsens_tz_sensor10
+device           gpu
+set_point        85000
+set_point_clr    55000
+override         15000
+
+[SS-POPMEM]
+#algo_type       ss
+sampling         10
+sensor           pop_mem
+device           cpu
+set_point        80000
+set_point_clr    55000
+override         15000
+time_constant    16
+
+[GPU_MONITOR]
+algo_type        monitor
+sensor           tsens_tz_sensor10
+sampling         1000
+thresholds       75000
+thresholds_clr   55000
+actions          battery
+action_info      1
+
 [CPU0_MONITOR]
 algo_type        monitor
 sensor           cpu0


### PR DESCRIPTION
* We routinely hit 80+C after reboot until things calm down. This is
  way too hot in my pants. Cool things down.
* Bring some aspects of the old thermal-engine config back.
* Shamelessly KANG most of the values from bacon.

Change-Id: I8e7f8ac40106ea7f5adca5b5d91b9bed36d7c202